### PR TITLE
Add responsive snapshot capture and CORS iframe support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,39 @@
+[run]
+source = percy
+branch = True
+parallel = True
+omit =
+    */tests/*
+    */test_*.py
+    */__pycache__/*
+    */site-packages/*
+    */.venv/*
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if False:
+    if __name__ == .__main__.:
+
+# Fail if coverage is below this threshold
+fail_under = 100
+show_missing = True
+precision = 2
+
+[html]
+directory = htmlcov
+
+[xml]
+output = coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,4 +61,4 @@ jobs:
           yarn remove @percy/cli && yarn link `echo $PERCY_PACKAGES`
           npx percy --version
        
-      - run: make test
+      - run: make test-coverage

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(VENV)/$(MARKER): $(VENVDEPS) | $(VENV)
 	$(VENV)/python -m playwright install
 	touch $(VENV)/$(MARKER)
 
-.PHONY: venv lint test clean build release
+.PHONY: venv lint test coverage test-coverage clean build release
 
 venv: $(VENV)/$(MARKER)
 
@@ -24,6 +24,20 @@ test: venv
 	npx percy exec --testing -- $(VENV)/python -m unittest tests.test_screenshot
 	$(VENV)/python -m unittest tests.test_cache
 	$(VENV)/python -m unittest tests.test_page_metadata
+	$(VENV)/python -m unittest tests.test_init
+
+test-coverage: coverage
+
+coverage: venv
+	$(VENV)/python -m coverage erase
+	npx percy exec --testing -- $(VENV)/python -m coverage run --branch --parallel-mode -m unittest tests.test_screenshot
+	$(VENV)/python -m coverage run --branch --parallel-mode -m unittest tests.test_cache
+	$(VENV)/python -m coverage run --branch --parallel-mode -m unittest tests.test_page_metadata
+	$(VENV)/python -m coverage run --branch --parallel-mode -m unittest tests.test_init
+	$(VENV)/python -m coverage combine
+	$(VENV)/python -m coverage report --fail-under=100
+	$(VENV)/python -m coverage html
+	$(VENV)/python -m coverage xml
 
 clean:
 	rm -rf $$(cat .gitignore)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(VENV)/$(MARKER): $(VENVDEPS) | $(VENV)
 	$(VENV)/python -m playwright install
 	touch $(VENV)/$(MARKER)
 
-.PHONY: venv lint test coverage test-coverage clean build release
+.PHONY: venv lint test test-coverage clean build release
 
 venv: $(VENV)/$(MARKER)
 
@@ -26,9 +26,7 @@ test: venv
 	$(VENV)/python -m unittest tests.test_page_metadata
 	$(VENV)/python -m unittest tests.test_init
 
-test-coverage: coverage
-
-coverage: venv
+test-coverage: venv
 	$(VENV)/python -m coverage erase
 	npx percy exec --testing -- $(VENV)/python -m coverage run --branch --parallel-mode -m unittest tests.test_screenshot
 	$(VENV)/python -m coverage run --branch --parallel-mode -m unittest tests.test_cache

--- a/development.txt
+++ b/development.txt
@@ -1,3 +1,4 @@
 httpretty==1.0.*
 pylint==2.*
 twine
+coverage==7.*

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "test": "make test"
   },
   "devDependencies": {
-    "@percy/cli": "1.30.9"
+    "@percy/cli": "^1.31.9-beta.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "test": "make test"
   },
   "devDependencies": {
-    "@percy/cli": "^1.31.9-beta.5"
+    "@percy/cli": "^1.31.9"
   }
 }

--- a/percy/__init__.py
+++ b/percy/__init__.py
@@ -4,8 +4,8 @@ from percy.screenshot import percy_automate_screenshot
 # import snapshot command
 try:
     from percy.screenshot import percy_snapshot
-except ImportError:
-
+except ImportError:  # pragma: no cover
+    # This is defensive code in case percy_snapshot is not available
     def percy_snapshot(page, *a, **kw):
         raise ModuleNotFoundError(
             "[percy] `percy-playwright-python` package is not installed, "

--- a/percy/screenshot.py
+++ b/percy/screenshot.py
@@ -1,7 +1,6 @@
 import os
 import json
 import platform
-from collections import OrderedDict
 from functools import lru_cache
 from time import sleep
 import requests
@@ -171,39 +170,29 @@ def calculate_default_height(page, current_height, **kwargs):
         return current_height
 
 
-def get_widths_for_multi_dom(eligible_widths, device_details, default_height, **kwargs):
-    user_passed_widths = kwargs.get("widths", [])
-    width = kwargs.get("width")
-    if width:
-        user_passed_widths = [width]
-
-    width_height_map = OrderedDict()
-
-    # Add mobile widths with their associated heights from device_details (if available)
-    mobile_widths = eligible_widths.get("mobile", [])
-    if mobile_widths:
-        for mobile_width in mobile_widths:
-            if mobile_width not in width_height_map:
-                device_info = next(
-                    (device for device in device_details if device.get("width") == mobile_width),
-                    None,
-                )
-                width_height_map[mobile_width] = {
-                    "width": mobile_width,
-                    "height": device_info.get("height", default_height)
-                    if device_info
-                    else default_height,
-                }
-
-    # Add user passed or config widths with default height
-    other_widths = (
-        user_passed_widths if len(user_passed_widths) != 0 else eligible_widths.get("config", [])
-    )
-    for w in other_widths:
-        if w not in width_height_map:
-            width_height_map[w] = {"width": w, "height": default_height}
-
-    return list(width_height_map.values())
+def get_responsive_widths(widths=None):
+    """Gets computed responsive widths from the Percy server for responsive snapshot capture."""
+    if widths is None:
+        widths = []
+    try:
+        # Ensure widths is a list
+        widths_list = widths if isinstance(widths, list) else []
+        query_param = f"?widths={','.join(map(str, widths_list))}" if widths_list else ""
+        response = requests.get(
+            f"{PERCY_CLI_API}/percy/widths-config{query_param}",
+            timeout=30
+        )
+        response.raise_for_status()
+        data = response.json()
+        widths_data = data.get("widths")
+        if not isinstance(widths_data, list):
+            msg = "Update Percy CLI to the latest version to use responsiveSnapshotCapture"
+            raise Exception(msg)
+        return widths_data
+    except Exception as e:
+        log(f"Failed to get responsive widths: {e}.", "debug")
+        msg = "Update Percy CLI to the latest version to use responsiveSnapshotCapture"
+        raise Exception(msg) from e
 
 
 def change_window_dimension_and_wait(page, width, height, resize_count):
@@ -220,16 +209,14 @@ def change_window_dimension_and_wait(page, width, height, resize_count):
         log(f"Timed out waiting for window resize event for width {width}", "debug")
 
 
-def capture_responsive_dom(page, eligible_widths, device_details, cookies, **kwargs):
+def capture_responsive_dom(page, cookies, **kwargs):
     viewport = page.viewport_size or page.evaluate(
         "() => ({ width: window.innerWidth, height: window.innerHeight })"
     )
     default_height = calculate_default_height(page, viewport["height"], **kwargs)
 
-    # Get width and height combinations
-    width_heights = get_widths_for_multi_dom(
-        eligible_widths, device_details, default_height, **kwargs
-    )
+    # Get width and height combinations from CLI
+    width_heights = get_responsive_widths(kwargs.get("widths", []))
 
     dom_snapshots = []
     last_window_width = viewport["width"]
@@ -237,12 +224,15 @@ def capture_responsive_dom(page, eligible_widths, device_details, cookies, **kwa
     page.evaluate("PercyDOM.waitForResize()")
 
     for width_height in width_heights:
-        if last_window_width != width_height["width"]:
+        # Apply default height if not provided by CLI
+        height = width_height.get("height") or default_height
+        width = width_height["width"]
+        if last_window_width != width:
             resize_count += 1
             change_window_dimension_and_wait(
-                page, width_height["width"], width_height["height"], resize_count
+                page, width, height, resize_count
             )
-            last_window_width = width_height["width"]
+            last_window_width = width
 
         if PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE:
             page.reload()
@@ -256,7 +246,7 @@ def capture_responsive_dom(page, eligible_widths, device_details, cookies, **kwa
             if sleep_time > 0:
                 sleep(sleep_time)
         dom_snapshot = get_serialized_dom(page, cookies, **kwargs)
-        dom_snapshot["width"] = width_height["width"]
+        dom_snapshot["width"] = width
         dom_snapshots.append(dom_snapshot)
 
     change_window_dimension_and_wait(
@@ -302,9 +292,7 @@ def percy_snapshot(page, name, **kwargs):
 
         # Serialize and capture the DOM
         if is_responsive_snapshot_capture(data["config"], **kwargs):
-            dom_snapshot = capture_responsive_dom(
-                page, data["widths"], data["device_details"], cookies, **kwargs
-            )
+            dom_snapshot = capture_responsive_dom(page, cookies, **kwargs)
         else:
             dom_snapshot = get_serialized_dom(page, cookies, **kwargs)
 

--- a/percy/screenshot.py
+++ b/percy/screenshot.py
@@ -256,21 +256,14 @@ def create_region(
 
 
 
-def calculate_default_height(page, current_height, **kwargs):
+def calculate_default_height(current_height, config=None, **kwargs):
     """Calculate default height for responsive capture."""
     if not PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT:
         return current_height
 
-    try:
-        min_height = kwargs.get("min_height") or current_height
-        return page.evaluate(
-            "(minH) => window.outerHeight - window.innerHeight + minH", min_height
-        )
-    except BaseException as exc:
-        # Do not swallow control-flow exceptions that should terminate the program.
-        if isinstance(exc, (KeyboardInterrupt, SystemExit)):
-            raise
-        return current_height
+    config_min_height = (config or {}).get("snapshot", {}).get("minHeight")
+    min_height = kwargs.get("min_height") or config_min_height or current_height
+    return min_height
 
 
 def get_responsive_widths(widths=None):
@@ -298,6 +291,17 @@ def get_responsive_widths(widths=None):
         raise Exception(msg) from e
 
 
+def _responsive_sleep():
+    """Sleep for the configured responsive capture sleep time if positive."""
+    if not RESPONSIVE_CAPTURE_SLEEP_TIME:
+        return
+    try:
+        if (secs := int(RESPONSIVE_CAPTURE_SLEEP_TIME)) > 0:
+            sleep(secs)
+    except (TypeError, ValueError):
+        pass
+
+
 def change_window_dimension_and_wait(page, width, height, resize_count):
     try:
         page.set_viewport_size({"width": width, "height": height})
@@ -312,11 +316,11 @@ def change_window_dimension_and_wait(page, width, height, resize_count):
         log(f"Timed out waiting for window resize event for width {width}", "debug")
 
 
-def capture_responsive_dom(page, cookies, percy_dom_script=None, **kwargs):
+def capture_responsive_dom(page, cookies, percy_dom_script=None, config=None, **kwargs):
     viewport = page.viewport_size or page.evaluate(
         "() => ({ width: window.innerWidth, height: window.innerHeight })"
     )
-    default_height = calculate_default_height(page, viewport["height"], **kwargs)
+    default_height = calculate_default_height(viewport["height"], config=config, **kwargs)
 
     # Get width and height combinations from CLI
     width_heights = get_responsive_widths(kwargs.get("widths", []))
@@ -343,16 +347,10 @@ def capture_responsive_dom(page, cookies, percy_dom_script=None, **kwargs):
             page.evaluate("PercyDOM.waitForResize()")
             resize_count = 0
 
-        if RESPONSIVE_CAPTURE_SLEEP_TIME:
-            try:
-                sleep_time = int(RESPONSIVE_CAPTURE_SLEEP_TIME)
-            except (TypeError, ValueError):
-                sleep_time = 0
-            if sleep_time > 0:
-                sleep(sleep_time)
-        dom_snapshot = get_serialized_dom(page, cookies, percy_dom_script, **kwargs)
-        dom_snapshot["width"] = width
-        dom_snapshots.append(dom_snapshot)
+        _responsive_sleep()
+        snapshot = get_serialized_dom(page, cookies, percy_dom_script, **kwargs)
+        snapshot["width"] = width
+        dom_snapshots.append(snapshot)
 
     change_window_dimension_and_wait(
         page, viewport["width"], viewport["height"], resize_count + 1
@@ -398,7 +396,9 @@ def percy_snapshot(page, name, **kwargs):
 
         # Serialize and capture the DOM
         if is_responsive_snapshot_capture(data["config"], **kwargs):
-            dom_snapshot = capture_responsive_dom(page, cookies, percy_dom_script, **kwargs)
+            dom_snapshot = capture_responsive_dom(
+                page, cookies, percy_dom_script, config=data["config"], **kwargs
+            )
         else:
             dom_snapshot = get_serialized_dom(page, cookies, percy_dom_script, **kwargs)
 

--- a/percy/screenshot.py
+++ b/percy/screenshot.py
@@ -15,12 +15,16 @@ from percy.page_metadata import PageMetaData
 CLIENT_INFO = "percy-playwright-python/" + SDK_VERSION
 ENV_INFO = ["playwright/" + PLAYWRIGHT_VERSION, "python/" + platform.python_version()]
 
+def _get_bool_env(key):
+    """Get boolean value from environment variable."""
+    return os.environ.get(key, "").lower() == "true"
+
 # Maybe get the CLI API address from the environment
 PERCY_CLI_API = os.environ.get("PERCY_CLI_API") or "http://localhost:5338"
 PERCY_DEBUG = os.environ.get("PERCY_LOGLEVEL") == "debug"
 RESPONSIVE_CAPTURE_SLEEP_TIME = os.environ.get("RESPONSIVE_CAPTURE_SLEEP_TIME")
-PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT = os.environ.get("PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT")
-PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE = os.environ.get("PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE")
+PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT = _get_bool_env("PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT")
+PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE = _get_bool_env("PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE")
 
 # for logging
 LABEL = "[\u001b[35m" + ("percy:python" if PERCY_DEBUG else "percy") + "\u001b[39m]"

--- a/percy/screenshot.py
+++ b/percy/screenshot.py
@@ -3,6 +3,7 @@ import json
 import platform
 from functools import lru_cache
 from time import sleep
+from urllib.parse import urlparse
 import requests
 
 from playwright._repo_version import version as PLAYWRIGHT_VERSION
@@ -90,6 +91,101 @@ def fetch_percy_dom():
     response.raise_for_status()
     return response.text
 
+
+def process_frame(page, frame, options, percy_dom_script):
+    """
+    Processes a single cross-origin frame to capture its snapshot and resources.
+
+    Args:
+        page: The main page object
+        frame: The frame to process
+        options: Snapshot options
+        percy_dom_script: The Percy DOM serialization script
+
+    Returns:
+        Dictionary containing iframe data, snapshot, and URL
+    """
+    frame_url = frame.url
+
+    try:
+        # Inject Percy DOM into the cross-origin frame
+        frame.evaluate(percy_dom_script)
+
+        # enableJavaScript=True prevents the standard iframe serialization logic from running.
+        # This is necessary because we're manually handling cross-origin iframe serialization here.
+        iframe_snapshot = frame.evaluate(
+            f"PercyDOM.serialize({json.dumps({**options, 'enableJavaScript': True})})"
+        )
+
+        # Get the iframe's element data from the main page context
+        iframe_data = page.evaluate(
+            """(fUrl) => {
+                const iframes = Array.from(document.querySelectorAll('iframe'));
+                const matchingIframe = iframes.find(iframe => iframe.src.startsWith(fUrl));
+                if (matchingIframe) {{
+                    return {{
+                        percyElementId: matchingIframe.getAttribute('data-percy-element-id')
+                    }};
+                }}
+            }""",
+            frame_url
+        )
+
+        return {
+            "iframeData": iframe_data,
+            "iframeSnapshot": iframe_snapshot,
+            "frameUrl": frame_url
+        }
+    except Exception as e:
+        log(f"Failed to process cross-origin frame {frame_url}: {e}", "debug")
+        return None
+
+
+def get_serialized_dom(page, cookies, percy_dom_script=None, **kwargs):
+    """
+    Serializes the DOM and captures cross-origin iframes.
+
+    Args:
+        page: The page object
+        cookies: Page cookies
+        percy_dom_script: The Percy DOM serialization script
+        **kwargs: Additional options
+
+    Returns:
+        Dictionary containing the DOM snapshot with cross-origin iframe data
+    """
+    dom_snapshot = page.evaluate(f"PercyDOM.serialize({json.dumps(kwargs)})")
+
+    # Process CORS IFrames
+    # Note: Blob URL handling (data-src images, blob background images) is now handled
+    # in the CLI via async DOM serialization. This section only handles cross-origin
+    # iframe serialization and resource merging.
+    try:
+        page_url = urlparse(page.url)
+        frames = page.frames
+
+        # Filter for cross-origin frames (excluding about:blank)
+        cross_origin_frames = [
+            frame for frame in frames
+            if frame.url != "about:blank" and urlparse(frame.url).netloc != page_url.netloc
+        ]
+
+        if cross_origin_frames and percy_dom_script:
+            processed_frames = []
+            for frame in cross_origin_frames:
+                result = process_frame(page, frame, kwargs, percy_dom_script)
+                if result:
+                    processed_frames.append(result)
+
+            if processed_frames:
+                dom_snapshot["corsIframes"] = processed_frames
+    except Exception as e:
+        log(f"Failed to process cross-origin iframes: {e}", "debug")
+
+    dom_snapshot["cookies"] = cookies
+    return dom_snapshot
+
+
 # pylint: disable=too-many-arguments, too-many-branches
 def create_region(
     boundingBox=None,
@@ -146,11 +242,6 @@ def create_region(
 
     return region
 
-
-def get_serialized_dom(page, cookies, **kwargs):
-    dom_snapshot = page.evaluate(f"PercyDOM.serialize({json.dumps(kwargs)})")
-    dom_snapshot["cookies"] = cookies
-    return dom_snapshot
 
 
 def calculate_default_height(page, current_height, **kwargs):
@@ -209,7 +300,7 @@ def change_window_dimension_and_wait(page, width, height, resize_count):
         log(f"Timed out waiting for window resize event for width {width}", "debug")
 
 
-def capture_responsive_dom(page, cookies, **kwargs):
+def capture_responsive_dom(page, cookies, percy_dom_script=None, **kwargs):
     viewport = page.viewport_size or page.evaluate(
         "() => ({ width: window.innerWidth, height: window.innerHeight })"
     )
@@ -237,6 +328,8 @@ def capture_responsive_dom(page, cookies, **kwargs):
         if PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE:
             page.reload()
             page.evaluate(fetch_percy_dom())
+            page.evaluate("PercyDOM.waitForResize()")
+            resize_count = 0
 
         if RESPONSIVE_CAPTURE_SLEEP_TIME:
             try:
@@ -245,7 +338,7 @@ def capture_responsive_dom(page, cookies, **kwargs):
                 sleep_time = 0
             if sleep_time > 0:
                 sleep(sleep_time)
-        dom_snapshot = get_serialized_dom(page, cookies, **kwargs)
+        dom_snapshot = get_serialized_dom(page, cookies, percy_dom_script, **kwargs)
         dom_snapshot["width"] = width
         dom_snapshots.append(dom_snapshot)
 
@@ -287,14 +380,15 @@ def percy_snapshot(page, name, **kwargs):
 
     try:
         # Inject the DOM serialization script
-        page.evaluate(fetch_percy_dom())
+        percy_dom_script = fetch_percy_dom()
+        page.evaluate(percy_dom_script)
         cookies = page.context.cookies()
 
         # Serialize and capture the DOM
         if is_responsive_snapshot_capture(data["config"], **kwargs):
-            dom_snapshot = capture_responsive_dom(page, cookies, **kwargs)
+            dom_snapshot = capture_responsive_dom(page, cookies, percy_dom_script, **kwargs)
         else:
-            dom_snapshot = get_serialized_dom(page, cookies, **kwargs)
+            dom_snapshot = get_serialized_dom(page, cookies, percy_dom_script, **kwargs)
 
         # Post the DOM to the snapshot endpoint with snapshot options and other info
         response = requests.post(

--- a/percy/screenshot.py
+++ b/percy/screenshot.py
@@ -122,11 +122,11 @@ def process_frame(page, frame, options, percy_dom_script):
             """(fUrl) => {
                 const iframes = Array.from(document.querySelectorAll('iframe'));
                 const matchingIframe = iframes.find(iframe => iframe.src.startsWith(fUrl));
-                if (matchingIframe) {{
-                    return {{
+                if (matchingIframe) {
+                    return {
                         percyElementId: matchingIframe.getAttribute('data-percy-element-id')
-                    }};
-                }}
+                    };
+                }
             }""",
             frame_url
         )

--- a/percy/screenshot.py
+++ b/percy/screenshot.py
@@ -1,10 +1,13 @@
 import os
 import json
 import platform
+from collections import OrderedDict
 from functools import lru_cache
+from time import sleep
 import requests
 
 from playwright._repo_version import version as PLAYWRIGHT_VERSION
+from playwright.sync_api import Error as PlaywrightError, TimeoutError as PlaywrightTimeoutError
 from percy.version import __version__ as SDK_VERSION
 from percy.page_metadata import PageMetaData
 
@@ -15,19 +18,41 @@ ENV_INFO = ["playwright/" + PLAYWRIGHT_VERSION, "python/" + platform.python_vers
 # Maybe get the CLI API address from the environment
 PERCY_CLI_API = os.environ.get("PERCY_CLI_API") or "http://localhost:5338"
 PERCY_DEBUG = os.environ.get("PERCY_LOGLEVEL") == "debug"
+RESPONSIVE_CAPTURE_SLEEP_TIME = os.environ.get("RESPONSIVE_CAPTURE_SLEEP_TIME")
+PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT = os.environ.get("PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT")
+PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE = os.environ.get("PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE")
 
 # for logging
 LABEL = "[\u001b[35m" + ("percy:python" if PERCY_DEBUG else "percy") + "\u001b[39m]"
 
+def log(message, lvl="info"):
+    message = f"{LABEL} {message}"
+    try:
+        requests.post(
+            f"{PERCY_CLI_API}/percy/log",
+            json={"message": message, "level": lvl},
+            timeout=5,
+        )
+    except Exception as e:
+        if PERCY_DEBUG:
+            print(f"Sending log to CLI Failed {e}")
+    finally:
+        # Only log if lvl is 'debug' and PERCY_DEBUG is True
+        if lvl != "debug" or PERCY_DEBUG:
+            print(message)
+
 
 # Check if Percy is enabled, caching the result so it is only checked once
 @lru_cache(maxsize=None)
-def is_percy_enabled():
+def _is_percy_enabled():
     try:
         response = requests.get(f"{PERCY_CLI_API}/percy/healthcheck", timeout=30)
         response.raise_for_status()
         data = response.json()
         session_type = data.get("type", None)
+        widths = data.get("widths", {})
+        config = data.get("config", {})
+        device_details = data.get("deviceDetails", [])
 
         if not data["success"]:
             raise Exception(data["error"])
@@ -46,7 +71,12 @@ def is_percy_enabled():
             print(f"{LABEL} Unsupported Percy CLI version, {version}")
             return False
 
-        return session_type
+        return {
+            "session_type": session_type,
+            "config": config,
+            "widths": widths,
+            "device_details": device_details,
+        }
     except Exception as e:
         print(f"{LABEL} Percy is not running, disabling snapshots")
         if PERCY_DEBUG:
@@ -118,12 +148,145 @@ def create_region(
     return region
 
 
+def get_serialized_dom(page, cookies, **kwargs):
+    dom_snapshot = page.evaluate(f"PercyDOM.serialize({json.dumps(kwargs)})")
+    dom_snapshot["cookies"] = cookies
+    return dom_snapshot
+
+
+def calculate_default_height(page, current_height, **kwargs):
+    """Calculate default height for responsive capture."""
+    if not PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT:
+        return current_height
+
+    try:
+        min_height = kwargs.get("min_height") or current_height
+        return page.evaluate(
+            "(minH) => window.outerHeight - window.innerHeight + minH", min_height
+        )
+    except BaseException as exc:
+        # Do not swallow control-flow exceptions that should terminate the program.
+        if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            raise
+        return current_height
+
+
+def get_widths_for_multi_dom(eligible_widths, device_details, default_height, **kwargs):
+    user_passed_widths = kwargs.get("widths", [])
+    width = kwargs.get("width")
+    if width:
+        user_passed_widths = [width]
+
+    width_height_map = OrderedDict()
+
+    # Add mobile widths with their associated heights from device_details (if available)
+    mobile_widths = eligible_widths.get("mobile", [])
+    if mobile_widths:
+        for mobile_width in mobile_widths:
+            if mobile_width not in width_height_map:
+                device_info = next(
+                    (device for device in device_details if device.get("width") == mobile_width),
+                    None,
+                )
+                width_height_map[mobile_width] = {
+                    "width": mobile_width,
+                    "height": device_info.get("height", default_height)
+                    if device_info
+                    else default_height,
+                }
+
+    # Add user passed or config widths with default height
+    other_widths = (
+        user_passed_widths if len(user_passed_widths) != 0 else eligible_widths.get("config", [])
+    )
+    for w in other_widths:
+        if w not in width_height_map:
+            width_height_map[w] = {"width": w, "height": default_height}
+
+    return list(width_height_map.values())
+
+
+def change_window_dimension_and_wait(page, width, height, resize_count):
+    try:
+        page.set_viewport_size({"width": width, "height": height})
+    except PlaywrightError as e:
+        log(f"Resizing viewport failed for width {width}: {e}", "debug")
+
+    try:
+        page.wait_for_function(
+            f"window.resizeCount === {resize_count}", timeout=1000
+        )
+    except PlaywrightTimeoutError:
+        log(f"Timed out waiting for window resize event for width {width}", "debug")
+
+
+def capture_responsive_dom(page, eligible_widths, device_details, cookies, **kwargs):
+    viewport = page.viewport_size or page.evaluate(
+        "() => ({ width: window.innerWidth, height: window.innerHeight })"
+    )
+    default_height = calculate_default_height(page, viewport["height"], **kwargs)
+
+    # Get width and height combinations
+    width_heights = get_widths_for_multi_dom(
+        eligible_widths, device_details, default_height, **kwargs
+    )
+
+    dom_snapshots = []
+    last_window_width = viewport["width"]
+    resize_count = 0
+    page.evaluate("PercyDOM.waitForResize()")
+
+    for width_height in width_heights:
+        if last_window_width != width_height["width"]:
+            resize_count += 1
+            change_window_dimension_and_wait(
+                page, width_height["width"], width_height["height"], resize_count
+            )
+            last_window_width = width_height["width"]
+
+        if PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE:
+            page.reload()
+            page.evaluate(fetch_percy_dom())
+
+        if RESPONSIVE_CAPTURE_SLEEP_TIME:
+            try:
+                sleep_time = int(RESPONSIVE_CAPTURE_SLEEP_TIME)
+            except (TypeError, ValueError):
+                sleep_time = 0
+            if sleep_time > 0:
+                sleep(sleep_time)
+        dom_snapshot = get_serialized_dom(page, cookies, **kwargs)
+        dom_snapshot["width"] = width_height["width"]
+        dom_snapshots.append(dom_snapshot)
+
+    change_window_dimension_and_wait(
+        page, viewport["width"], viewport["height"], resize_count + 1
+    )
+    return dom_snapshots
+
+
+def is_responsive_snapshot_capture(config, **kwargs):
+    # Don't run responsive snapshot capture when defer uploads is enabled
+    if "percy" in config and config["percy"].get("deferUploads", False):
+        return False
+
+    return (
+        kwargs.get("responsive_snapshot_capture", False)
+        or kwargs.get("responsiveSnapshotCapture", False)
+        or (
+            "snapshot" in config
+            and config["snapshot"].get("responsiveSnapshotCapture")
+        )
+    )
+
+
 # Take a DOM snapshot and post it to the snapshot endpoint
 def percy_snapshot(page, name, **kwargs):
-    session_type = is_percy_enabled()
-    if session_type is False:
-        return None  # Since session_type can be None for old CLI version
-    if session_type == "automate":
+    data = _is_percy_enabled()
+    if not data:
+        return None
+
+    if data["session_type"] == "automate":
         raise Exception(
             "Invalid function call - "
             "percy_snapshot(). "
@@ -134,14 +297,16 @@ def percy_snapshot(page, name, **kwargs):
 
     try:
         # Inject the DOM serialization script
-        # print(fetch_percy_dom())
         page.evaluate(fetch_percy_dom())
+        cookies = page.context.cookies()
 
         # Serialize and capture the DOM
-        dom_snapshot_script = f"PercyDOM.serialize({json.dumps(kwargs)})"
-
-        # Return the serialized DOM Snapshot
-        dom_snapshot = page.evaluate(dom_snapshot_script)
+        if is_responsive_snapshot_capture(data["config"], **kwargs):
+            dom_snapshot = capture_responsive_dom(
+                page, data["widths"], data["device_details"], cookies, **kwargs
+            )
+        else:
+            dom_snapshot = get_serialized_dom(page, cookies, **kwargs)
 
         # Post the DOM to the snapshot endpoint with snapshot options and other info
         response = requests.post(
@@ -161,22 +326,23 @@ def percy_snapshot(page, name, **kwargs):
 
         # Handle errors
         response.raise_for_status()
-        data = response.json()
+        response_data = response.json()
 
-        if not data["success"]:
-            raise Exception(data["error"])
-        return data.get("data", None)
+        if not response_data["success"]:
+            raise Exception(response_data["error"])
+        return response_data.get("data", None)
     except Exception as e:
-        print(f'{LABEL} Could not take DOM snapshot "{name}"')
-        print(f"{LABEL} {e}")
+        log(f'Could not take DOM snapshot "{name}"')
+        log(f"{e}")
         return None
 
 
 def percy_automate_screenshot(page, name, options=None, **kwargs):
-    session_type = is_percy_enabled()
-    if session_type is False:
-        return None  # Since session_type can be None for old CLI version
-    if session_type == "web":
+    data = _is_percy_enabled()
+    if not data:
+        return None
+
+    if data["session_type"] == "web":
         raise Exception(
             "Invalid function call - "
             "percy_screenshot(). Please use percy_snapshot() function for taking screenshot. "
@@ -212,13 +378,13 @@ def percy_automate_screenshot(page, name, options=None, **kwargs):
 
         # Handle errors
         response.raise_for_status()
-        data = response.json()
+        response_data = response.json()
 
-        if not data["success"]:
-            raise Exception(data["error"])
+        if not response_data["success"]:
+            raise Exception(response_data["error"])
 
-        return data.get("data", None)
+        return response_data.get("data", None)
     except Exception as e:
-        print(f'{LABEL} Could not take Screenshot "{name}"')
-        print(f"{LABEL} {e}")
+        log(f'Could not take Screenshot "{name}"')
+        log(f"{e}")
         return None

--- a/percy/screenshot.py
+++ b/percy/screenshot.py
@@ -131,6 +131,14 @@ def process_frame(page, frame, options, percy_dom_script):
             frame_url
         )
 
+        if not iframe_data or not iframe_data.get("percyElementId"):
+            log(
+                f"Skipping cross-origin frame {frame_url}: "
+                "no matching iframe element with percyElementId found on main page",
+                "debug"
+            )
+            return None
+
         return {
             "iframeData": iframe_data,
             "iframeSnapshot": iframe_snapshot,

--- a/percy/screenshot.py
+++ b/percy/screenshot.py
@@ -339,7 +339,7 @@ def capture_responsive_dom(page, cookies, percy_dom_script=None, **kwargs):
 
         if PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE:
             page.reload()
-            page.evaluate(fetch_percy_dom())
+            page.evaluate(percy_dom_script)
             page.evaluate("PercyDOM.waitForResize()")
             resize_count = 0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-playwright==1.28.*
+playwright==1.40.*
 requests==2.*

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,49 @@
+# pylint: disable=[abstract-class-instantiated, arguments-differ, protected-access]
+import unittest
+from unittest.mock import patch, MagicMock
+import percy
+
+
+class TestPercyInit(unittest.TestCase):
+    @patch("percy.percy_snapshot")
+    def test_percySnapshot_wrapper(self, mock_percy_snapshot):
+        """Test the percySnapshot backwards compatibility wrapper."""
+        mock_page = MagicMock()
+        mock_percy_snapshot.return_value = "snapshot_result"
+
+        # Call via percy module to test the wrapper
+        # percySnapshot(browser, *a, **kw) calls percy_snapshot(page=browser, *a, **kw)
+        result = percy.percySnapshot(mock_page, "test_name", some_option=True)
+
+        # Verify percy_snapshot was called correctly
+        # Check that the function was called
+        self.assertTrue(mock_percy_snapshot.called)
+        # Check page argument and keyword argument
+        actual_call = mock_percy_snapshot.call_args
+        self.assertEqual(actual_call.kwargs['page'], mock_page)
+        self.assertEqual(actual_call.kwargs['some_option'], True)
+        self.assertEqual(result, "snapshot_result")
+
+    @patch("percy.percy_automate_screenshot")
+    def test_percy_screenshot_wrapper(self, mock_automate_screenshot):
+        """Test the percy_screenshot wrapper."""
+        mock_page = MagicMock()
+        mock_automate_screenshot.return_value = "screenshot_result"
+
+        # Call via percy module to test the wrapper
+        result = percy.percy_screenshot(mock_page, "test_name", options={"key": "value"})
+
+        # Verify percy_automate_screenshot was called correctly
+        mock_automate_screenshot.assert_called_once_with(
+            mock_page, "test_name", options={"key": "value"}
+        )
+        self.assertEqual(result, "screenshot_result")
+
+    def test_version_imported(self):
+        """Test that __version__ is properly imported."""
+        self.assertIsNotNone(percy.__version__)
+        self.assertIsInstance(percy.__version__, str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,21 +1,28 @@
-# pylint: disable=[abstract-class-instantiated, arguments-differ, protected-access]
+# pylint: disable=[abstract-class-instantiated, arguments-differ, protected-access, too-many-lines]
 import json
 import unittest
 import platform
 from threading import Thread
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 import httpretty
 
 from playwright.sync_api import sync_playwright
+from playwright.sync_api import Error as PlaywrightError, TimeoutError as PlaywrightTimeoutError
 from playwright._repo_version import version as PLAYWRIGHT_VERSION
 from percy.version import __version__ as SDK_VERSION
 from percy.screenshot import (
-    is_percy_enabled,
+    _is_percy_enabled,
     fetch_percy_dom,
     percy_snapshot,
     percy_automate_screenshot,
-    create_region
+    create_region,
+    is_responsive_snapshot_capture,
+    calculate_default_height,
+    get_widths_for_multi_dom,
+    capture_responsive_dom,
+    change_window_dimension_and_wait,
+    log
 )
 import percy.screenshot as local
 
@@ -45,7 +52,11 @@ data_object = {"sync": "true", "diff": 0}
 
 
 # mock helpers
-def mock_healthcheck(fail=False, fail_how="error", session_type=None):
+# pylint: disable=too-many-arguments
+def mock_healthcheck(
+    fail=False, fail_how="error", session_type=None,
+    widths=None, config=None, device_details=None
+):
     health_body = {"success": True}
     health_headers = {"X-Percy-Core-Version": "1.0.0"}
     health_status = 200
@@ -60,6 +71,12 @@ def mock_healthcheck(fail=False, fail_how="error", session_type=None):
 
     if session_type:
         health_body["type"] = session_type
+    if widths:
+        health_body["widths"] = widths
+    if config:
+        health_body["config"] = config
+    if device_details:
+        health_body["deviceDetails"] = device_details
 
     health_body = json.dumps(health_body)
     httpretty.register_uri(
@@ -72,7 +89,21 @@ def mock_healthcheck(fail=False, fail_how="error", session_type=None):
     httpretty.register_uri(
         httpretty.GET,
         "http://localhost:5338/percy/dom.js",
-        body="window.PercyDOM = { serialize: () => document.documentElement.outerHTML };",
+        body=(
+            "window.PercyDOM = { serialize: () => { return { html: "
+            "document.documentElement.outerHTML } }, waitForResize: () => { "
+            "if(!window.resizeCount) { window.addEventListener('resize', () => "
+            "window.resizeCount++) } window.resizeCount = 0; }}"
+        ),
+        status=200,
+    )
+
+
+def mock_logger():
+    httpretty.register_uri(
+        httpretty.POST,
+        "http://localhost:5338/percy/log",
+        body=json.dumps({"success": True}),
         status=200,
     )
 
@@ -110,7 +141,7 @@ class TestPercySnapshot(unittest.TestCase):
 
     def setUp(self):
         # clear the cached value for testing
-        local.is_percy_enabled.cache_clear()
+        local._is_percy_enabled.cache_clear()
         local.fetch_percy_dom.cache_clear()
         self.page.goto("http://localhost:8000")
         httpretty.enable()
@@ -181,8 +212,9 @@ class TestPercySnapshot(unittest.TestCase):
         self.assertEqual(s1["name"], "Snapshot 1")
         self.assertEqual(s1["url"], "http://localhost:8000/")
         self.assertEqual(
-            s1["dom_snapshot"], "<html><head></head><body>Snapshot Me</body></html>"
+            s1["dom_snapshot"]["html"], "<html><head></head><body>Snapshot Me</body></html>"
         )
+        self.assertIn("cookies", s1["dom_snapshot"])
         self.assertRegex(s1["client_info"], r"percy-playwright-python/\d+")
         self.assertRegex(s1["environment_info"][0], r"playwright/\d+")
         self.assertRegex(s1["environment_info"][1], r"python/\d+")
@@ -207,8 +239,9 @@ class TestPercySnapshot(unittest.TestCase):
         self.assertEqual(s1["name"], "Snapshot 1")
         self.assertEqual(s1["url"], "http://localhost:8000/")
         self.assertEqual(
-            s1["dom_snapshot"], "<html><head></head><body>Snapshot Me</body></html>"
+            s1["dom_snapshot"]["html"], "<html><head></head><body>Snapshot Me</body></html>"
         )
+        self.assertIn("cookies", s1["dom_snapshot"])
         self.assertRegex(s1["client_info"], r"percy-playwright-python/\d+")
         self.assertRegex(s1["environment_info"][0], r"playwright/\d+")
         self.assertRegex(s1["environment_info"][1], r"python/\d+")
@@ -230,12 +263,14 @@ class TestPercySnapshot(unittest.TestCase):
         self.assertEqual(s1["name"], "Snapshot")
         self.assertEqual(s1["url"], "http://localhost:8000/")
         self.assertEqual(
-            s1["dom_snapshot"], "<html><head></head><body>Snapshot Me</body></html>"
+            s1["dom_snapshot"]["html"], "<html><head></head><body>Snapshot Me</body></html>"
         )
+        self.assertIn("cookies", s1["dom_snapshot"])
 
     def test_handles_snapshot_errors(self):
         mock_healthcheck(session_type="web")
         mock_snapshot(fail=True)
+        mock_logger()
 
         with patch("builtins.print") as mock_print:
             percy_snapshot(self.page, "Snapshot 1")
@@ -265,40 +300,66 @@ class TestPercyFunctions(unittest.TestCase):
     def test_is_percy_enabled(self, mock_get):
         # Mock successful health check
         mock_get.return_value.status_code = 200
-        mock_get.return_value.json.return_value = {"success": True, "type": "web"}
+        mock_get.return_value.json.return_value = {
+            "success": True,
+            "type": "web",
+            "config": {},
+            "widths": {},
+            "deviceDetails": [],
+        }
         mock_get.return_value.headers = {"x-percy-core-version": "1.0.0"}
 
-        self.assertEqual(is_percy_enabled(), "web")
+        self.assertEqual(
+            _is_percy_enabled(),
+            {
+                "session_type": "web",
+                "config": {},
+                "widths": {},
+                "device_details": [],
+            },
+        )
 
         # Clear the cache to test the unsuccessful scenario
-        is_percy_enabled.cache_clear()
+        _is_percy_enabled.cache_clear()
 
         # Mock unsuccessful health check
         mock_get.return_value.json.return_value = {"success": False, "error": "error"}
-        self.assertFalse(is_percy_enabled())
+        self.assertFalse(_is_percy_enabled())
 
     @patch("requests.get")
     def test_fetch_percy_dom(self, mock_get):
         # Mock successful fetch of dom.js
+        fetch_percy_dom.cache_clear()
         mock_get.return_value.status_code = 200
         mock_get.return_value.text = "some_js_code"
 
         self.assertEqual(fetch_percy_dom(), "some_js_code")
 
+    @patch("requests.get")
+    def test_fetch_percy_dom_raises(self, mock_get):
+        fetch_percy_dom.cache_clear()
+        mock_get.return_value.raise_for_status.side_effect = Exception("boom")
+
+        with self.assertRaises(Exception):
+            fetch_percy_dom()
+
     @patch("requests.post")
     @patch("percy.screenshot.fetch_percy_dom")
-    @patch("percy.screenshot.is_percy_enabled")
+    @patch("percy.screenshot._is_percy_enabled")
     def test_percy_snapshot(
         self, mock_is_percy_enabled, mock_fetch_percy_dom, mock_post
     ):
         # Mock Percy enabled
-        mock_is_percy_enabled.return_value = "web"
+        mock_is_percy_enabled.return_value = {
+            "session_type": "web",
+            "config": {},
+            "widths": {},
+            "device_details": [],
+        }
         mock_fetch_percy_dom.return_value = "some_js_code"
         page = MagicMock()
-        page.evaluate.side_effect = [
-            "dom_snapshot",
-            json.dumps({"hashed_id": "session-id"}),
-        ]
+        page.evaluate.side_effect = [None, {"html": "<html></html>"}]
+        page.context.cookies.return_value = []
         page.url = "http://example.com"
         mock_post.return_value.status_code = 200
         mock_post.return_value.json.return_value = {
@@ -314,11 +375,89 @@ class TestPercyFunctions(unittest.TestCase):
         mock_post.assert_called_once()
 
     @patch("requests.post")
-    @patch("percy.screenshot.is_percy_enabled")
+    @patch("percy.screenshot.fetch_percy_dom")
+    @patch("percy.screenshot._is_percy_enabled")
+    def test_percy_snapshot_includes_cookies(
+        self, mock_is_percy_enabled, mock_fetch_percy_dom, mock_post
+    ):
+        mock_is_percy_enabled.return_value = {
+            "session_type": "web",
+            "config": {},
+            "widths": {},
+            "device_details": [],
+        }
+        mock_fetch_percy_dom.return_value = "some_js_code"
+        page = MagicMock()
+        page.evaluate.side_effect = [None, {"html": "<html></html>"}]
+        page.context.cookies.return_value = [{"name": "foo", "value": "bar"}]
+        page.url = "http://example.com"
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "success": True,
+            "data": "snapshot_data",
+        }
+
+        percy_snapshot(page, "snapshot_name")
+
+        posted = mock_post.call_args.kwargs["json"]
+        self.assertEqual(
+            posted["dom_snapshot"]["cookies"], [{"name": "foo", "value": "bar"}]
+        )
+
+    @patch("requests.post")
+    @patch("percy.screenshot.capture_responsive_dom")
+    @patch("percy.screenshot.fetch_percy_dom")
+    @patch("percy.screenshot._is_percy_enabled")
+    def test_percy_snapshot_responsive_capture(
+        self,
+        mock_is_percy_enabled,
+        mock_fetch_percy_dom,
+        mock_capture_responsive_dom,
+        mock_post,
+    ):
+        mock_is_percy_enabled.return_value = {
+            "session_type": "web",
+            "config": {"snapshot": {"responsiveSnapshotCapture": True}},
+            "widths": {"config": [375, 1280]},
+            "device_details": [{"width": 375, "height": 667}],
+        }
+        mock_fetch_percy_dom.return_value = "some_js_code"
+        mock_capture_responsive_dom.return_value = [
+            {"html": "<html></html>", "width": 375},
+            {"html": "<html></html>", "width": 1280},
+        ]
+        page = MagicMock()
+        page.evaluate.return_value = None
+        page.context.cookies.return_value = [{"name": "foo", "value": "bar"}]
+        page.url = "http://example.com"
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "success": True,
+            "data": "snapshot_data",
+        }
+
+        percy_snapshot(page, "snapshot_name")
+
+        mock_capture_responsive_dom.assert_called_once_with(
+            page,
+            {"config": [375, 1280]},
+            [{"width": 375, "height": 667}],
+            [{"name": "foo", "value": "bar"}],
+        )
+        posted = mock_post.call_args.kwargs["json"]
+        self.assertEqual(posted["dom_snapshot"], mock_capture_responsive_dom.return_value)
+
+    @patch("requests.post")
+    @patch("percy.screenshot._is_percy_enabled")
     def test_percy_automate_screenshot(self, mock_is_percy_enabled, mock_post):
         # Mock Percy enabled for automate
-        is_percy_enabled.cache_clear()
-        mock_is_percy_enabled.return_value = "automate"
+        _is_percy_enabled.cache_clear()
+        mock_is_percy_enabled.return_value = {
+            "session_type": "automate",
+            "config": {},
+            "widths": {},
+            "device_details": [],
+        }
         page = MagicMock()
 
         page._impl_obj._guid = "page@abc"
@@ -356,10 +495,27 @@ class TestPercyFunctions(unittest.TestCase):
             timeout=600,
         )
 
-    @patch("percy.screenshot.is_percy_enabled")
+    @patch("percy.screenshot._is_percy_enabled")
+    def test_percy_automate_screenshot_percy_disabled(self, mock_is_percy_enabled):
+        """Test percy_automate_screenshot when Percy is not enabled."""
+        _is_percy_enabled.cache_clear()
+        mock_is_percy_enabled.return_value = False
+
+        page = MagicMock()
+        result = percy_automate_screenshot(page, "screenshot_name")
+
+        # Should return None when Percy is disabled
+        self.assertIsNone(result)
+
+    @patch("percy.screenshot._is_percy_enabled")
     def test_percy_automate_screenshot_invalid_call(self, mock_is_percy_enabled):
         # Mock Percy enabled for web
-        mock_is_percy_enabled.return_value = "web"
+        mock_is_percy_enabled.return_value = {
+            "session_type": "web",
+            "config": {},
+            "widths": {},
+            "device_details": [],
+        }
         page = MagicMock()
 
         # Call the function and expect an exception
@@ -367,6 +523,270 @@ class TestPercyFunctions(unittest.TestCase):
             percy_automate_screenshot(page, "screenshot_name")
 
         self.assertTrue("Invalid function call" in str(context.exception))
+
+    @patch("requests.post")
+    @patch("percy.screenshot._is_percy_enabled")
+    def test_percy_automate_screenshot_with_options(self, mock_is_percy_enabled, mock_post):
+        """Test percy_automate_screenshot when options are provided (not None)."""
+        # Mock Percy enabled for automate
+        _is_percy_enabled.cache_clear()
+        mock_is_percy_enabled.return_value = {
+            "session_type": "automate",
+            "config": {},
+            "widths": {},
+            "device_details": [],
+        }
+        page = MagicMock()
+
+        page._impl_obj._guid = "page@xyz"
+        page.main_frame._impl_obj._guid = "frame@xyz"
+        page.context.browser._impl_obj._guid = "browser@xyz"
+        page.evaluate.return_value = '{"hashed_id": "session_xyz"}'
+
+        # Mock the response for the POST request
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "success": True,
+            "data": "screenshot_with_options",
+        }
+
+        # Call the function with explicit options (not None)
+        test_options = {"freeze_animated_image": True, "freeze_image_by_selectors": [".animated"]}
+        result = percy_automate_screenshot(page, "screenshot_name", options=test_options)
+
+        # Assertions
+        self.assertEqual(result, "screenshot_with_options")
+        call_args = mock_post.call_args
+        self.assertEqual(call_args.kwargs["json"]["options"], test_options)
+
+
+class TestScreenshotEdgeCases(unittest.TestCase):
+    def setUp(self):
+        _is_percy_enabled.cache_clear()
+        fetch_percy_dom.cache_clear()
+
+    @patch("requests.get")
+    def test_is_percy_enabled_request_error(self, mock_get):
+        mock_get.side_effect = Exception("boom")
+        with patch.object(local, "PERCY_DEBUG", True), patch("builtins.print") as mock_print:
+            self.assertFalse(_is_percy_enabled())
+            mock_print.assert_any_call(
+                f"{LABEL} Percy is not running, disabling snapshots"
+            )
+
+    @patch("requests.get")
+    def test_is_percy_enabled_raise_for_status(self, mock_get):
+        mock_get.return_value.raise_for_status.side_effect = Exception("boom")
+        mock_get.return_value.json.return_value = {"success": True}
+        with patch.object(local, "PERCY_DEBUG", False):
+            self.assertFalse(_is_percy_enabled())
+
+    def test_log_debug_when_enabled(self):
+        with patch("requests.post", side_effect=Exception("boom")), patch.object(
+            local, "PERCY_DEBUG", True
+        ), patch("builtins.print") as mock_print:
+            log("message", lvl="debug")
+            mock_print.assert_any_call("Sending log to CLI Failed boom")
+            mock_print.assert_any_call(f"{LABEL} message")
+
+    def test_log_debug_when_disabled(self):
+        with patch("requests.post") as mock_post, patch.object(
+            local, "PERCY_DEBUG", False
+        ), patch("builtins.print") as mock_print:
+            mock_post.return_value.status_code = 200
+            log("message", lvl="debug")
+            mock_print.assert_not_called()
+
+    def test_log_info_level(self):
+        """Test log function with info level (should always print)."""
+        with patch("requests.post") as mock_post, patch.object(
+            local, "PERCY_DEBUG", False
+        ), patch("builtins.print") as mock_print:
+            mock_post.return_value.status_code = 200
+            log("info message", lvl="info")
+            mock_print.assert_called_once_with(f"{LABEL} info message")
+
+    def test_log_exception_debug_disabled(self):
+        """Test log function when exception occurs and PERCY_DEBUG is False."""
+        with patch("requests.post", side_effect=Exception("connection error")), patch.object(
+            local, "PERCY_DEBUG", False
+        ), patch("builtins.print") as mock_print:
+            log("message with error", lvl="info")
+            # Should still print the message in finally block, but not the exception
+            mock_print.assert_called_once_with(f"{LABEL} message with error")
+
+    def test_change_window_dimension_and_wait_errors(self):
+        page = MagicMock()
+        page.set_viewport_size.side_effect = PlaywrightError("boom")
+        page.wait_for_function.side_effect = PlaywrightTimeoutError("boom")
+
+        with patch("percy.screenshot.log") as mock_log:
+            change_window_dimension_and_wait(page, 100, 200, 1)
+
+        self.assertEqual(mock_log.call_count, 2)
+
+    def test_capture_responsive_dom_no_reload_or_sleep(self):
+        page = MagicMock()
+        page.viewport_size = {"width": 800, "height": 600}
+        page.evaluate = MagicMock()
+        page.reload = MagicMock()
+
+        with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE", None), patch.object(
+            local, "RESPONSIVE_CAPTURE_SLEEP_TIME", None
+        ), patch(
+            "percy.screenshot.get_widths_for_multi_dom"
+        ) as mock_widths, patch(
+            "percy.screenshot.get_serialized_dom"
+        ) as mock_serialized, patch(
+            "percy.screenshot.change_window_dimension_and_wait"
+        ) as mock_resize:
+            mock_widths.return_value = [{"width": 800, "height": 600}]
+            mock_serialized.return_value = {"html": "<html></html>"}
+
+            capture_responsive_dom(
+                page, {"config": [800]}, [], [{"name": "foo", "value": "bar"}]
+            )
+
+        page.reload.assert_not_called()
+        page.evaluate.assert_any_call("PercyDOM.waitForResize()")
+        mock_resize.assert_called_once_with(page, 800, 600, 1)
+
+    def test_capture_responsive_dom_none_viewport_falls_back_to_js(self):
+        page = MagicMock()
+        page.viewport_size = None
+        page.evaluate = MagicMock(
+            side_effect=lambda expr: {"width": 1024, "height": 768}
+            if "innerWidth" in expr
+            else None
+        )
+        page.reload = MagicMock()
+
+        with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE", None), patch.object(
+            local, "RESPONSIVE_CAPTURE_SLEEP_TIME", None
+        ), patch(
+            "percy.screenshot.get_widths_for_multi_dom"
+        ) as mock_widths, patch(
+            "percy.screenshot.get_serialized_dom"
+        ) as mock_serialized, patch(
+            "percy.screenshot.change_window_dimension_and_wait"
+        ) as mock_resize:
+            mock_widths.return_value = [{"width": 1024, "height": 768}]
+            mock_serialized.return_value = {"html": "<html></html>"}
+
+            capture_responsive_dom(
+                page, {"config": [1024]}, [], [{"name": "foo", "value": "bar"}]
+            )
+
+        page.evaluate.assert_any_call(
+            "() => ({ width: window.innerWidth, height: window.innerHeight })"
+        )
+        mock_resize.assert_called_once_with(page, 1024, 768, 1)
+
+    @patch("requests.post")
+    @patch("percy.screenshot.fetch_percy_dom")
+    @patch("percy.screenshot._is_percy_enabled")
+    def test_percy_snapshot_response_error(
+        self, mock_is_percy_enabled, mock_fetch_percy_dom, mock_post
+    ):
+        mock_is_percy_enabled.return_value = {
+            "session_type": "web",
+            "config": {},
+            "widths": {},
+            "device_details": [],
+        }
+        mock_fetch_percy_dom.return_value = "some_js_code"
+        page = MagicMock()
+        page.evaluate.side_effect = [None, {"html": "<html></html>"}]
+        page.context.cookies.return_value = []
+        page.url = "http://example.com"
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "success": False,
+            "error": "bad",
+        }
+
+        with patch("percy.screenshot.log") as mock_log:
+            result = percy_snapshot(page, "snapshot_name")
+
+        self.assertIsNone(result)
+        mock_log.assert_any_call('Could not take DOM snapshot "snapshot_name"')
+
+    @patch("requests.post")
+    @patch("percy.screenshot.fetch_percy_dom")
+    @patch("percy.screenshot._is_percy_enabled")
+    def test_percy_snapshot_request_error(
+        self, mock_is_percy_enabled, mock_fetch_percy_dom, mock_post
+    ):
+        mock_is_percy_enabled.return_value = {
+            "session_type": "web",
+            "config": {},
+            "widths": {},
+            "device_details": [],
+        }
+        mock_fetch_percy_dom.return_value = "some_js_code"
+        page = MagicMock()
+        page.evaluate.side_effect = [None, {"html": "<html></html>"}]
+        page.context.cookies.return_value = []
+        page.url = "http://example.com"
+        mock_post.side_effect = Exception("boom")
+
+        with patch("percy.screenshot.log") as mock_log:
+            result = percy_snapshot(page, "snapshot_name")
+
+        self.assertIsNone(result)
+        mock_log.assert_any_call('Could not take DOM snapshot "snapshot_name"')
+
+    @patch("requests.post")
+    @patch("percy.screenshot._is_percy_enabled")
+    def test_percy_automate_screenshot_response_error(
+        self, mock_is_percy_enabled, mock_post
+    ):
+        mock_is_percy_enabled.return_value = {
+            "session_type": "automate",
+            "config": {},
+            "widths": {},
+            "device_details": [],
+        }
+        page = MagicMock()
+        page._impl_obj._guid = "page@abc"
+        page.main_frame._impl_obj._guid = "frame@abc"
+        page.context.browser._impl_obj._guid = "browser@abc"
+        page.evaluate.return_value = '{"hashed_id": "session_id"}'
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "success": False,
+            "error": "bad",
+        }
+
+        with patch("percy.screenshot.log") as mock_log:
+            result = percy_automate_screenshot(page, "screenshot_name")
+
+        self.assertIsNone(result)
+        mock_log.assert_any_call('Could not take Screenshot "screenshot_name"')
+
+    @patch("requests.post")
+    @patch("percy.screenshot._is_percy_enabled")
+    def test_percy_automate_screenshot_request_error(
+        self, mock_is_percy_enabled, mock_post
+    ):
+        mock_is_percy_enabled.return_value = {
+            "session_type": "automate",
+            "config": {},
+            "widths": {},
+            "device_details": [],
+        }
+        page = MagicMock()
+        page._impl_obj._guid = "page@abc"
+        page.main_frame._impl_obj._guid = "frame@abc"
+        page.context.browser._impl_obj._guid = "browser@abc"
+        page.evaluate.return_value = '{"hashed_id": "session_id"}'
+        mock_post.side_effect = Exception("boom")
+
+        with patch("percy.screenshot.log") as mock_log:
+            result = percy_automate_screenshot(page, "screenshot_name")
+
+        self.assertIsNone(result)
+        mock_log.assert_any_call('Could not take Screenshot "screenshot_name"')
 
 class TestCreateRegion(unittest.TestCase):
 
@@ -406,6 +826,248 @@ class TestCreateRegion(unittest.TestCase):
         }
 
         self.assertEqual(result, expected_result)
+
+
+# pylint: disable=too-many-public-methods
+class TestResponsiveHelpers(unittest.TestCase):
+    def test_is_responsive_snapshot_capture_from_kwargs(self):
+        self.assertTrue(is_responsive_snapshot_capture({}, responsive_snapshot_capture=True))
+        self.assertTrue(is_responsive_snapshot_capture({}, responsiveSnapshotCapture=True))
+
+    def test_is_responsive_snapshot_capture_from_config(self):
+        config = {"snapshot": {"responsiveSnapshotCapture": True}}
+        self.assertTrue(is_responsive_snapshot_capture(config))
+
+    def test_is_responsive_snapshot_capture_defer_uploads(self):
+        config = {
+            "percy": {"deferUploads": True},
+            "snapshot": {"responsiveSnapshotCapture": True},
+        }
+        self.assertFalse(is_responsive_snapshot_capture(config, responsiveSnapshotCapture=True))
+
+    def test_calculate_default_height_env_disabled(self):
+        page = MagicMock()
+        with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT", None):
+            self.assertEqual(calculate_default_height(page, 123), 123)
+            page.evaluate.assert_not_called()
+
+    def test_calculate_default_height_env_enabled(self):
+        page = MagicMock()
+        page.evaluate.return_value = 456
+        with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT", "1"):
+            self.assertEqual(calculate_default_height(page, 123, min_height=200), 456)
+            page.evaluate.assert_called_once_with(
+                "(minH) => window.outerHeight - window.innerHeight + minH", 200
+            )
+
+    def test_calculate_default_height_env_enabled_handles_error(self):
+        page = MagicMock()
+        page.evaluate.side_effect = PlaywrightError("boom")
+        with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT", "1"):
+            self.assertEqual(calculate_default_height(page, 321), 321)
+
+    def test_calculate_default_height_reraises_keyboard_interrupt(self):
+        page = MagicMock()
+        page.evaluate.side_effect = KeyboardInterrupt()
+        with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT", "1"):
+            with self.assertRaises(KeyboardInterrupt):
+                calculate_default_height(page, 321)
+
+    def test_calculate_default_height_reraises_system_exit(self):
+        page = MagicMock()
+        page.evaluate.side_effect = SystemExit()
+        with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT", "1"):
+            with self.assertRaises(SystemExit):
+                calculate_default_height(page, 321)
+
+    def test_get_widths_for_multi_dom(self):
+        eligible_widths = {"mobile": [375], "config": [1280]}
+        device_details = [{"width": 375, "height": 667}]
+        widths = get_widths_for_multi_dom(eligible_widths, device_details, 900)
+
+        self.assertEqual(
+            widths,
+            [
+                {"width": 375, "height": 667},
+                {"width": 1280, "height": 900},
+            ],
+        )
+
+    def test_get_widths_for_multi_dom_user_width_override(self):
+        eligible_widths = {"mobile": [375], "config": [1280]}
+        device_details = []
+        widths = get_widths_for_multi_dom(
+            eligible_widths, device_details, 900, width=1024
+        )
+
+        self.assertEqual(
+            widths,
+            [
+                {"width": 375, "height": 900},
+                {"width": 1024, "height": 900},
+            ],
+        )
+
+    def test_get_widths_for_multi_dom_with_widths_list(self):
+        """Test get_widths_for_multi_dom with user-provided widths list."""
+        eligible_widths = {"mobile": [375], "config": [1280]}
+        device_details = [{"width": 375, "height": 667}]
+        # Pass widths as a list (not using width parameter)
+        widths = get_widths_for_multi_dom(
+            eligible_widths, device_details, 900, widths=[800, 1024]
+        )
+
+        # Should include mobile width with device height, and user widths
+        self.assertEqual(len(widths), 3)
+        self.assertIn({"width": 375, "height": 667}, widths)
+        self.assertIn({"width": 800, "height": 900}, widths)
+        self.assertIn({"width": 1024, "height": 900}, widths)
+
+    def test_get_widths_for_multi_dom_mobile_without_device_info(self):
+        """Test get_widths_for_multi_dom when device_info is None for mobile width."""
+        eligible_widths = {"mobile": [375, 768], "config": [1280]}
+        # Only provide device details for 375, not for 768
+        device_details = [{"width": 375, "height": 667}]
+        widths = get_widths_for_multi_dom(eligible_widths, device_details, 900)
+
+        # 768 should use default_height since no device_info
+        expected = [
+            {"width": 375, "height": 667},
+            {"width": 768, "height": 900},  # Uses default_height
+            {"width": 1280, "height": 900},
+        ]
+        self.assertEqual(widths, expected)
+
+    def test_get_widths_for_multi_dom_duplicate_widths(self):
+        """Test get_widths_for_multi_dom when same width appears in mobile and config."""
+        eligible_widths = {"mobile": [375, 1280], "config": [1280, 1920]}
+        device_details = [{"width": 375, "height": 667}, {"width": 1280, "height": 800}]
+        widths = get_widths_for_multi_dom(eligible_widths, device_details, 900)
+
+        # 1280 should only appear once (from mobile with device height)
+        self.assertEqual(len(widths), 3)
+        self.assertIn({"width": 375, "height": 667}, widths)
+        self.assertIn({"width": 1280, "height": 800}, widths)  # From mobile with device info
+        self.assertIn({"width": 1920, "height": 900}, widths)
+
+    def test_get_widths_for_multi_dom_no_mobile_widths(self):
+        """Test get_widths_for_multi_dom with no mobile widths."""
+        eligible_widths = {"mobile": [], "config": [1280, 1920]}
+        device_details = []
+        widths = get_widths_for_multi_dom(eligible_widths, device_details, 900)
+
+        # Should only have config widths
+        self.assertEqual(len(widths), 2)
+        self.assertIn({"width": 1280, "height": 900}, widths)
+        self.assertIn({"width": 1920, "height": 900}, widths)
+
+    def test_get_widths_for_multi_dom_mobile_width_already_in_map(self):
+        """Test when a mobile width appears multiple times (edge case for branch coverage)."""
+        # This is a contrived test to hit the branch where width is already in width_height_map
+        # during the mobile widths loop
+        eligible_widths = {"mobile": [375, 375], "config": [1280]}  # Duplicate 375
+        device_details = [{"width": 375, "height": 667}]
+        widths = get_widths_for_multi_dom(eligible_widths, device_details, 900)
+
+        # Should only have 375 once and 1280
+        self.assertEqual(len(widths), 2)
+        self.assertIn({"width": 375, "height": 667}, widths)
+        self.assertIn({"width": 1280, "height": 900}, widths)
+
+    def test_capture_responsive_dom_calls_resize_reload_sleep(self):
+        page = MagicMock()
+        page.viewport_size = {"width": 800, "height": 600}
+        page.evaluate = MagicMock()
+        page.reload = MagicMock()
+
+        with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE", "1"), patch.object(
+            local, "RESPONSIVE_CAPTURE_SLEEP_TIME", "1"
+        ), patch(
+            "percy.screenshot.get_widths_for_multi_dom"
+        ) as mock_widths, patch(
+            "percy.screenshot.get_serialized_dom"
+        ) as mock_serialized, patch(
+            "percy.screenshot.change_window_dimension_and_wait"
+        ) as mock_resize, patch(
+            "percy.screenshot.fetch_percy_dom"
+        ) as mock_fetch, patch(
+            "percy.screenshot.sleep"
+        ) as mock_sleep:
+            mock_widths.return_value = [
+                {"width": 800, "height": 600},
+                {"width": 1200, "height": 700},
+            ]
+            mock_serialized.side_effect = [
+                {"html": "<html></html>"},
+                {"html": "<html></html>"},
+            ]
+            mock_fetch.return_value = "dom-script"
+
+            result = capture_responsive_dom(
+                page, {"config": [800, 1200]}, [], [{"name": "foo", "value": "bar"}]
+            )
+
+        page.evaluate.assert_any_call("PercyDOM.waitForResize()")
+        page.evaluate.assert_any_call("dom-script")
+        self.assertEqual(page.evaluate.call_count, 3)
+        self.assertEqual(page.reload.call_count, 2)
+        mock_sleep.assert_any_call(1)
+        self.assertEqual(mock_sleep.call_count, 2)
+        mock_resize.assert_has_calls(
+            [
+                call(page, 1200, 700, 1),
+                call(page, 800, 600, 2),
+            ]
+        )
+        self.assertEqual(result[0]["width"], 800)
+        self.assertEqual(result[1]["width"], 1200)
+
+    def test_capture_responsive_dom_invalid_sleep_time(self):
+        page = MagicMock()
+        page.viewport_size = {"width": 800, "height": 600}
+        page.evaluate = MagicMock()
+        page.reload = MagicMock()
+
+        with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE", None), patch.object(
+            local, "RESPONSIVE_CAPTURE_SLEEP_TIME", "not-a-number"
+        ), patch(
+            "percy.screenshot.get_widths_for_multi_dom"
+        ) as mock_widths, patch(
+            "percy.screenshot.get_serialized_dom"
+        ) as mock_serialized, patch(
+            "percy.screenshot.change_window_dimension_and_wait"
+        ), patch(
+            "percy.screenshot.sleep"
+        ) as mock_sleep:
+            mock_widths.return_value = [{"width": 800, "height": 600}]
+            mock_serialized.return_value = {"html": "<html></html>"}
+
+            capture_responsive_dom(page, {"config": [800]}, [], [])
+
+        mock_sleep.assert_not_called()
+
+    def test_capture_responsive_dom_zero_sleep_time(self):
+        page = MagicMock()
+        page.viewport_size = {"width": 800, "height": 600}
+        page.evaluate = MagicMock()
+
+        with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE", None), patch.object(
+            local, "RESPONSIVE_CAPTURE_SLEEP_TIME", "0"
+        ), patch(
+            "percy.screenshot.get_widths_for_multi_dom"
+        ) as mock_widths, patch(
+            "percy.screenshot.get_serialized_dom"
+        ) as mock_serialized, patch(
+            "percy.screenshot.change_window_dimension_and_wait"
+        ), patch(
+            "percy.screenshot.sleep"
+        ) as mock_sleep:
+            mock_widths.return_value = [{"width": 800, "height": 600}]
+            mock_serialized.return_value = {"html": "<html></html>"}
+
+            capture_responsive_dom(page, {"config": [800]}, [], [])
+
+        mock_sleep.assert_not_called()
 
     def test_create_region_with_minimal_params(self):
         result = create_region(

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -19,7 +19,7 @@ from percy.screenshot import (
     create_region,
     is_responsive_snapshot_capture,
     calculate_default_height,
-    get_widths_for_multi_dom,
+    get_responsive_widths,
     capture_responsive_dom,
     change_window_dimension_and_wait,
     log
@@ -418,8 +418,6 @@ class TestPercyFunctions(unittest.TestCase):
         mock_is_percy_enabled.return_value = {
             "session_type": "web",
             "config": {"snapshot": {"responsiveSnapshotCapture": True}},
-            "widths": {"config": [375, 1280]},
-            "device_details": [{"width": 375, "height": 667}],
         }
         mock_fetch_percy_dom.return_value = "some_js_code"
         mock_capture_responsive_dom.return_value = [
@@ -440,8 +438,6 @@ class TestPercyFunctions(unittest.TestCase):
 
         mock_capture_responsive_dom.assert_called_once_with(
             page,
-            {"config": [375, 1280]},
-            [{"width": 375, "height": 667}],
             [{"name": "foo", "value": "bar"}],
         )
         posted = mock_post.call_args.kwargs["json"]
@@ -455,8 +451,6 @@ class TestPercyFunctions(unittest.TestCase):
         mock_is_percy_enabled.return_value = {
             "session_type": "automate",
             "config": {},
-            "widths": {},
-            "device_details": [],
         }
         page = MagicMock()
 
@@ -513,8 +507,6 @@ class TestPercyFunctions(unittest.TestCase):
         mock_is_percy_enabled.return_value = {
             "session_type": "web",
             "config": {},
-            "widths": {},
-            "device_details": [],
         }
         page = MagicMock()
 
@@ -533,8 +525,6 @@ class TestPercyFunctions(unittest.TestCase):
         mock_is_percy_enabled.return_value = {
             "session_type": "automate",
             "config": {},
-            "widths": {},
-            "device_details": [],
         }
         page = MagicMock()
 
@@ -634,7 +624,7 @@ class TestScreenshotEdgeCases(unittest.TestCase):
         with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE", None), patch.object(
             local, "RESPONSIVE_CAPTURE_SLEEP_TIME", None
         ), patch(
-            "percy.screenshot.get_widths_for_multi_dom"
+            "percy.screenshot.get_responsive_widths"
         ) as mock_widths, patch(
             "percy.screenshot.get_serialized_dom"
         ) as mock_serialized, patch(
@@ -643,9 +633,7 @@ class TestScreenshotEdgeCases(unittest.TestCase):
             mock_widths.return_value = [{"width": 800, "height": 600}]
             mock_serialized.return_value = {"html": "<html></html>"}
 
-            capture_responsive_dom(
-                page, {"config": [800]}, [], [{"name": "foo", "value": "bar"}]
-            )
+            capture_responsive_dom(page, [{"name": "foo", "value": "bar"}])
 
         page.reload.assert_not_called()
         page.evaluate.assert_any_call("PercyDOM.waitForResize()")
@@ -664,7 +652,7 @@ class TestScreenshotEdgeCases(unittest.TestCase):
         with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE", None), patch.object(
             local, "RESPONSIVE_CAPTURE_SLEEP_TIME", None
         ), patch(
-            "percy.screenshot.get_widths_for_multi_dom"
+            "percy.screenshot.get_responsive_widths"
         ) as mock_widths, patch(
             "percy.screenshot.get_serialized_dom"
         ) as mock_serialized, patch(
@@ -673,9 +661,7 @@ class TestScreenshotEdgeCases(unittest.TestCase):
             mock_widths.return_value = [{"width": 1024, "height": 768}]
             mock_serialized.return_value = {"html": "<html></html>"}
 
-            capture_responsive_dom(
-                page, {"config": [1024]}, [], [{"name": "foo", "value": "bar"}]
-            )
+            capture_responsive_dom(page, [{"name": "foo", "value": "bar"}])
 
         page.evaluate.assert_any_call(
             "() => ({ width: window.innerWidth, height: window.innerHeight })"
@@ -691,8 +677,6 @@ class TestScreenshotEdgeCases(unittest.TestCase):
         mock_is_percy_enabled.return_value = {
             "session_type": "web",
             "config": {},
-            "widths": {},
-            "device_details": [],
         }
         mock_fetch_percy_dom.return_value = "some_js_code"
         page = MagicMock()
@@ -720,8 +704,6 @@ class TestScreenshotEdgeCases(unittest.TestCase):
         mock_is_percy_enabled.return_value = {
             "session_type": "web",
             "config": {},
-            "widths": {},
-            "device_details": [],
         }
         mock_fetch_percy_dom.return_value = "some_js_code"
         page = MagicMock()
@@ -744,8 +726,6 @@ class TestScreenshotEdgeCases(unittest.TestCase):
         mock_is_percy_enabled.return_value = {
             "session_type": "automate",
             "config": {},
-            "widths": {},
-            "device_details": [],
         }
         page = MagicMock()
         page._impl_obj._guid = "page@abc"
@@ -772,8 +752,6 @@ class TestScreenshotEdgeCases(unittest.TestCase):
         mock_is_percy_enabled.return_value = {
             "session_type": "automate",
             "config": {},
-            "widths": {},
-            "device_details": [],
         }
         page = MagicMock()
         page._impl_obj._guid = "page@abc"
@@ -880,10 +858,17 @@ class TestResponsiveHelpers(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 calculate_default_height(page, 321)
 
-    def test_get_widths_for_multi_dom(self):
-        eligible_widths = {"mobile": [375], "config": [1280]}
-        device_details = [{"width": 375, "height": 667}]
-        widths = get_widths_for_multi_dom(eligible_widths, device_details, 900)
+    @patch("requests.get")
+    def test_get_responsive_widths(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {
+            "widths": [
+                {"width": 375, "height": 667},
+                {"width": 1280, "height": 900},
+            ]
+        }
+
+        widths = get_responsive_widths([375, 1280])
 
         self.assertEqual(
             widths,
@@ -892,87 +877,67 @@ class TestResponsiveHelpers(unittest.TestCase):
                 {"width": 1280, "height": 900},
             ],
         )
-
-    def test_get_widths_for_multi_dom_user_width_override(self):
-        eligible_widths = {"mobile": [375], "config": [1280]}
-        device_details = []
-        widths = get_widths_for_multi_dom(
-            eligible_widths, device_details, 900, width=1024
+        mock_get.assert_called_once_with(
+            "http://localhost:5338/percy/widths-config?widths=375,1280",
+            timeout=30,
         )
+
+    @patch("requests.get")
+    def test_get_responsive_widths_missing_widths(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"widths": "not-a-list"}
+
+        with self.assertRaises(Exception) as context:
+            get_responsive_widths([800])
+
+        self.assertEqual(
+            str(context.exception),
+            "Update Percy CLI to the latest version to use responsiveSnapshotCapture",
+        )
+
+    @patch("requests.get")
+    def test_get_responsive_widths_with_none(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {
+            "widths": [
+                {"width": 375, "height": 667},
+            ]
+        }
+
+        widths = get_responsive_widths(None)
 
         self.assertEqual(
             widths,
             [
-                {"width": 375, "height": 900},
-                {"width": 1024, "height": 900},
+                {"width": 375, "height": 667},
             ],
         )
-
-    def test_get_widths_for_multi_dom_with_widths_list(self):
-        """Test get_widths_for_multi_dom with user-provided widths list."""
-        eligible_widths = {"mobile": [375], "config": [1280]}
-        device_details = [{"width": 375, "height": 667}]
-        # Pass widths as a list (not using width parameter)
-        widths = get_widths_for_multi_dom(
-            eligible_widths, device_details, 900, widths=[800, 1024]
+        mock_get.assert_called_once_with(
+            "http://localhost:5338/percy/widths-config",
+            timeout=30,
         )
 
-        # Should include mobile width with device height, and user widths
-        self.assertEqual(len(widths), 3)
-        self.assertIn({"width": 375, "height": 667}, widths)
-        self.assertIn({"width": 800, "height": 900}, widths)
-        self.assertIn({"width": 1024, "height": 900}, widths)
+    @patch("requests.get")
+    def test_get_responsive_widths_with_empty_list(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {
+            "widths": [
+                {"width": 375, "height": 667},
+            ]
+        }
 
-    def test_get_widths_for_multi_dom_mobile_without_device_info(self):
-        """Test get_widths_for_multi_dom when device_info is None for mobile width."""
-        eligible_widths = {"mobile": [375, 768], "config": [1280]}
-        # Only provide device details for 375, not for 768
-        device_details = [{"width": 375, "height": 667}]
-        widths = get_widths_for_multi_dom(eligible_widths, device_details, 900)
+        widths = get_responsive_widths([])
 
-        # 768 should use default_height since no device_info
-        expected = [
-            {"width": 375, "height": 667},
-            {"width": 768, "height": 900},  # Uses default_height
-            {"width": 1280, "height": 900},
-        ]
-        self.assertEqual(widths, expected)
-
-    def test_get_widths_for_multi_dom_duplicate_widths(self):
-        """Test get_widths_for_multi_dom when same width appears in mobile and config."""
-        eligible_widths = {"mobile": [375, 1280], "config": [1280, 1920]}
-        device_details = [{"width": 375, "height": 667}, {"width": 1280, "height": 800}]
-        widths = get_widths_for_multi_dom(eligible_widths, device_details, 900)
-
-        # 1280 should only appear once (from mobile with device height)
-        self.assertEqual(len(widths), 3)
-        self.assertIn({"width": 375, "height": 667}, widths)
-        self.assertIn({"width": 1280, "height": 800}, widths)  # From mobile with device info
-        self.assertIn({"width": 1920, "height": 900}, widths)
-
-    def test_get_widths_for_multi_dom_no_mobile_widths(self):
-        """Test get_widths_for_multi_dom with no mobile widths."""
-        eligible_widths = {"mobile": [], "config": [1280, 1920]}
-        device_details = []
-        widths = get_widths_for_multi_dom(eligible_widths, device_details, 900)
-
-        # Should only have config widths
-        self.assertEqual(len(widths), 2)
-        self.assertIn({"width": 1280, "height": 900}, widths)
-        self.assertIn({"width": 1920, "height": 900}, widths)
-
-    def test_get_widths_for_multi_dom_mobile_width_already_in_map(self):
-        """Test when a mobile width appears multiple times (edge case for branch coverage)."""
-        # This is a contrived test to hit the branch where width is already in width_height_map
-        # during the mobile widths loop
-        eligible_widths = {"mobile": [375, 375], "config": [1280]}  # Duplicate 375
-        device_details = [{"width": 375, "height": 667}]
-        widths = get_widths_for_multi_dom(eligible_widths, device_details, 900)
-
-        # Should only have 375 once and 1280
-        self.assertEqual(len(widths), 2)
-        self.assertIn({"width": 375, "height": 667}, widths)
-        self.assertIn({"width": 1280, "height": 900}, widths)
+        self.assertEqual(
+            widths,
+            [
+                {"width": 375, "height": 667},
+            ],
+        )
+        mock_get.assert_called_once_with(
+            "http://localhost:5338/percy/widths-config",
+            timeout=30,
+        )
 
     def test_capture_responsive_dom_calls_resize_reload_sleep(self):
         page = MagicMock()
@@ -983,7 +948,7 @@ class TestResponsiveHelpers(unittest.TestCase):
         with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE", "1"), patch.object(
             local, "RESPONSIVE_CAPTURE_SLEEP_TIME", "1"
         ), patch(
-            "percy.screenshot.get_widths_for_multi_dom"
+            "percy.screenshot.get_responsive_widths"
         ) as mock_widths, patch(
             "percy.screenshot.get_serialized_dom"
         ) as mock_serialized, patch(
@@ -1003,9 +968,7 @@ class TestResponsiveHelpers(unittest.TestCase):
             ]
             mock_fetch.return_value = "dom-script"
 
-            result = capture_responsive_dom(
-                page, {"config": [800, 1200]}, [], [{"name": "foo", "value": "bar"}]
-            )
+            result = capture_responsive_dom(page, [{"name": "foo", "value": "bar"}])
 
         page.evaluate.assert_any_call("PercyDOM.waitForResize()")
         page.evaluate.assert_any_call("dom-script")
@@ -1031,7 +994,7 @@ class TestResponsiveHelpers(unittest.TestCase):
         with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE", None), patch.object(
             local, "RESPONSIVE_CAPTURE_SLEEP_TIME", "not-a-number"
         ), patch(
-            "percy.screenshot.get_widths_for_multi_dom"
+            "percy.screenshot.get_responsive_widths"
         ) as mock_widths, patch(
             "percy.screenshot.get_serialized_dom"
         ) as mock_serialized, patch(
@@ -1042,7 +1005,7 @@ class TestResponsiveHelpers(unittest.TestCase):
             mock_widths.return_value = [{"width": 800, "height": 600}]
             mock_serialized.return_value = {"html": "<html></html>"}
 
-            capture_responsive_dom(page, {"config": [800]}, [], [])
+            capture_responsive_dom(page, [])
 
         mock_sleep.assert_not_called()
 
@@ -1054,7 +1017,7 @@ class TestResponsiveHelpers(unittest.TestCase):
         with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE", None), patch.object(
             local, "RESPONSIVE_CAPTURE_SLEEP_TIME", "0"
         ), patch(
-            "percy.screenshot.get_widths_for_multi_dom"
+            "percy.screenshot.get_responsive_widths"
         ) as mock_widths, patch(
             "percy.screenshot.get_serialized_dom"
         ) as mock_serialized, patch(
@@ -1065,9 +1028,56 @@ class TestResponsiveHelpers(unittest.TestCase):
             mock_widths.return_value = [{"width": 800, "height": 600}]
             mock_serialized.return_value = {"html": "<html></html>"}
 
-            capture_responsive_dom(page, {"config": [800]}, [], [])
+            capture_responsive_dom(page, [])
 
         mock_sleep.assert_not_called()
+
+    def test_capture_responsive_dom_skips_resize_for_same_width(self):
+        """Test that resize is skipped when consecutive widths are the same."""
+        page = MagicMock()
+        page.viewport_size = {"width": 800, "height": 600}
+        page.evaluate = MagicMock()
+
+        with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE", None), patch.object(
+            local, "RESPONSIVE_CAPTURE_SLEEP_TIME", None
+        ), patch(
+            "percy.screenshot.get_responsive_widths"
+        ) as mock_widths, patch(
+            "percy.screenshot.get_serialized_dom"
+        ) as mock_serialized, patch(
+            "percy.screenshot.change_window_dimension_and_wait"
+        ) as mock_resize:
+            # Test with duplicate widths: 800 (same as viewport), 1200, 1200 (duplicate), 1400
+            mock_widths.return_value = [
+                {"width": 800, "height": 600},
+                {"width": 1200, "height": 700},
+                {"width": 1200, "height": 700},  # Duplicate - should not trigger resize
+                {"width": 1400, "height": 800},
+            ]
+            mock_serialized.side_effect = [
+                {"html": "<html></html>"},
+                {"html": "<html></html>"},
+                {"html": "<html></html>"},
+                {"html": "<html></html>"},
+            ]
+
+            result = capture_responsive_dom(page, [])
+
+        # Verify resize is called only when width changes:
+        # 1. First width (800) matches viewport - no resize
+        # 2. Second width (1200) differs - resize to 1200
+        # 3. Third width (1200) same as previous - no resize
+        # 4. Fourth width (1400) differs - resize to 1400
+        # 5. Final restore to viewport (800) - resize to 800
+        mock_resize.assert_has_calls(
+            [
+                call(page, 1200, 700, 1),  # First change from 800 to 1200
+                call(page, 1400, 800, 2),  # Second change from 1200 to 1400
+                call(page, 800, 600, 3),   # Final restore
+            ]
+        )
+        self.assertEqual(mock_resize.call_count, 3)
+        self.assertEqual(len(result), 4)  # All 4 widths should have snapshots
 
     def test_create_region_with_minimal_params(self):
         result = create_region(

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -471,6 +471,42 @@ class TestPercyFunctions(unittest.TestCase):
         self.assertIsNone(result)
         mock_log.assert_called_once()
 
+    def test_process_frame_returns_none_when_iframe_data_missing(self):
+        page = MagicMock()
+        page.evaluate.return_value = None  # iframe element not found on main page
+
+        frame = MagicMock()
+        frame.url = "http://cross-origin.example/frame"
+        frame.evaluate.side_effect = [None, {"html": "<iframe></iframe>"}]
+
+        with patch("percy.screenshot.log") as mock_log:
+            result = process_frame(page, frame, {}, "percy-dom-script")
+
+        self.assertIsNone(result)
+        mock_log.assert_called_once_with(
+            "Skipping cross-origin frame http://cross-origin.example/frame: "
+            "no matching iframe element with percyElementId found on main page",
+            "debug"
+        )
+
+    def test_process_frame_returns_none_when_percy_element_id_missing(self):
+        page = MagicMock()
+        page.evaluate.return_value = {}  # iframe found but lacks percyElementId
+
+        frame = MagicMock()
+        frame.url = "http://cross-origin.example/frame"
+        frame.evaluate.side_effect = [None, {"html": "<iframe></iframe>"}]
+
+        with patch("percy.screenshot.log") as mock_log:
+            result = process_frame(page, frame, {}, "percy-dom-script")
+
+        self.assertIsNone(result)
+        mock_log.assert_called_once_with(
+            "Skipping cross-origin frame http://cross-origin.example/frame: "
+            "no matching iframe element with percyElementId found on main page",
+            "debug"
+        )
+
     def test_get_serialized_dom_skips_empty_cors_results(self):
         page = MagicMock()
         page.url = "http://example.com"

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1116,7 +1116,7 @@ class TestResponsiveHelpers(unittest.TestCase):
             ]
             mock_fetch.return_value = "dom-script"
 
-            result = capture_responsive_dom(page, [{"name": "foo", "value": "bar"}])
+            result = capture_responsive_dom(page, [{"name": "foo", "value": "bar"}], "dom-script")
 
         page.evaluate.assert_any_call("PercyDOM.waitForResize()")
         page.evaluate.assert_any_call("dom-script")

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -22,6 +22,8 @@ from percy.screenshot import (
     get_responsive_widths,
     capture_responsive_dom,
     change_window_dimension_and_wait,
+    get_serialized_dom,
+    process_frame,
     log
 )
 import percy.screenshot as local
@@ -404,6 +406,115 @@ class TestPercyFunctions(unittest.TestCase):
             posted["dom_snapshot"]["cookies"], [{"name": "foo", "value": "bar"}]
         )
 
+    def test_process_frame_returns_cors_iframe_data(self):
+        page = MagicMock()
+        page.evaluate.return_value = {"percyElementId": "iframe-1"}
+
+        frame = MagicMock()
+        frame.url = "http://cross-origin.example/frame"
+        frame.evaluate.side_effect = [None, {"html": "<iframe></iframe>"}]
+
+        result = process_frame(
+            page,
+            frame,
+            {"enableJavaScript": False},
+            "percy-dom-script"
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "iframeData": {"percyElementId": "iframe-1"},
+                "iframeSnapshot": {"html": "<iframe></iframe>"},
+                "frameUrl": "http://cross-origin.example/frame",
+            },
+        )
+
+    def test_get_serialized_dom_adds_cors_iframes(self):
+        page = MagicMock()
+        page.url = "http://example.com"
+        page.evaluate.return_value = {"html": "<html></html>"}
+
+        same_origin_frame = MagicMock()
+        same_origin_frame.url = "http://example.com/frame"
+        cross_origin_frame = MagicMock()
+        cross_origin_frame.url = "http://other.example/frame"
+        page.frames = [same_origin_frame, cross_origin_frame]
+
+        with patch("percy.screenshot.process_frame") as mock_process:
+            mock_process.return_value = {"frameUrl": "http://other.example/frame"}
+            dom_snapshot = get_serialized_dom(
+                page,
+                [{"name": "foo", "value": "bar"}],
+                percy_dom_script="percy-dom"
+            )
+
+        mock_process.assert_called_once_with(page, cross_origin_frame, {}, "percy-dom")
+        self.assertEqual(
+            dom_snapshot["corsIframes"],
+            [{"frameUrl": "http://other.example/frame"}]
+        )
+        self.assertEqual(
+            dom_snapshot["cookies"],
+            [{"name": "foo", "value": "bar"}]
+        )
+
+    def test_process_frame_returns_none_on_error(self):
+        page = MagicMock()
+        frame = MagicMock()
+        frame.url = "http://cross-origin.example/frame"
+        frame.evaluate.side_effect = Exception("boom")
+
+        with patch("percy.screenshot.log") as mock_log:
+            result = process_frame(page, frame, {}, "percy-dom-script")
+
+        self.assertIsNone(result)
+        mock_log.assert_called_once()
+
+    def test_get_serialized_dom_skips_empty_cors_results(self):
+        page = MagicMock()
+        page.url = "http://example.com"
+        page.evaluate.return_value = {"html": "<html></html>"}
+        cross_origin_frame = MagicMock()
+        cross_origin_frame.url = "http://other.example/frame"
+        page.frames = [cross_origin_frame]
+
+        with patch("percy.screenshot.process_frame") as mock_process:
+            mock_process.return_value = None
+            dom_snapshot = get_serialized_dom(
+                page,
+                [{"name": "foo", "value": "bar"}],
+                percy_dom_script="percy-dom"
+            )
+
+        self.assertNotIn("corsIframes", dom_snapshot)
+        self.assertEqual(
+            dom_snapshot["cookies"],
+            [{"name": "foo", "value": "bar"}]
+        )
+
+    def test_get_serialized_dom_logs_when_frame_processing_fails(self):
+        class BadUrl:
+            def __str__(self):
+                raise Exception("boom")
+
+        page = MagicMock()
+        page.url = BadUrl()
+        page.evaluate.return_value = {"html": "<html></html>"}
+
+        with patch("percy.screenshot.log") as mock_log:
+            dom_snapshot = get_serialized_dom(
+                page,
+                [{"name": "foo", "value": "bar"}],
+                percy_dom_script="percy-dom"
+            )
+
+        mock_log.assert_called_once()
+        self.assertEqual(
+            dom_snapshot["cookies"],
+            [{"name": "foo", "value": "bar"}]
+        )
+
     @patch("requests.post")
     @patch("percy.screenshot.capture_responsive_dom")
     @patch("percy.screenshot.fetch_percy_dom")
@@ -439,6 +550,7 @@ class TestPercyFunctions(unittest.TestCase):
         mock_capture_responsive_dom.assert_called_once_with(
             page,
             [{"name": "foo", "value": "bar"}],
+            "some_js_code",
         )
         posted = mock_post.call_args.kwargs["json"]
         self.assertEqual(posted["dom_snapshot"], mock_capture_responsive_dom.return_value)
@@ -972,14 +1084,14 @@ class TestResponsiveHelpers(unittest.TestCase):
 
         page.evaluate.assert_any_call("PercyDOM.waitForResize()")
         page.evaluate.assert_any_call("dom-script")
-        self.assertEqual(page.evaluate.call_count, 3)
+        self.assertEqual(page.evaluate.call_count, 5)
         self.assertEqual(page.reload.call_count, 2)
         mock_sleep.assert_any_call(1)
         self.assertEqual(mock_sleep.call_count, 2)
         mock_resize.assert_has_calls(
             [
                 call(page, 1200, 700, 1),
-                call(page, 800, 600, 2),
+                call(page, 800, 600, 1),
             ]
         )
         self.assertEqual(result[0]["width"], 800)

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -494,7 +494,7 @@ class TestPercyFunctions(unittest.TestCase):
         )
 
     def test_get_serialized_dom_logs_when_frame_processing_fails(self):
-        class BadUrl:
+        class BadUrl:  # pylint: disable=too-few-public-methods
             def __str__(self):
                 raise Exception("boom")
 

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -587,6 +587,7 @@ class TestPercyFunctions(unittest.TestCase):
             page,
             [{"name": "foo", "value": "bar"}],
             "some_js_code",
+            config={"snapshot": {"responsiveSnapshotCapture": True}},
         )
         posted = mock_post.call_args.kwargs["json"]
         self.assertEqual(posted["dom_snapshot"], mock_capture_responsive_dom.return_value)
@@ -972,39 +973,25 @@ class TestResponsiveHelpers(unittest.TestCase):
         self.assertFalse(is_responsive_snapshot_capture(config, responsiveSnapshotCapture=True))
 
     def test_calculate_default_height_env_disabled(self):
-        page = MagicMock()
         with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT", None):
-            self.assertEqual(calculate_default_height(page, 123), 123)
-            page.evaluate.assert_not_called()
+            self.assertEqual(calculate_default_height(123), 123)
 
     def test_calculate_default_height_env_enabled(self):
-        page = MagicMock()
-        page.evaluate.return_value = 456
         with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT", "1"):
-            self.assertEqual(calculate_default_height(page, 123, min_height=200), 456)
-            page.evaluate.assert_called_once_with(
-                "(minH) => window.outerHeight - window.innerHeight + minH", 200
-            )
+            self.assertEqual(calculate_default_height(123, min_height=200), 200)
 
     def test_calculate_default_height_env_enabled_handles_error(self):
-        page = MagicMock()
-        page.evaluate.side_effect = PlaywrightError("boom")
         with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT", "1"):
-            self.assertEqual(calculate_default_height(page, 321), 321)
+            self.assertEqual(calculate_default_height(321), 321)
 
-    def test_calculate_default_height_reraises_keyboard_interrupt(self):
-        page = MagicMock()
-        page.evaluate.side_effect = KeyboardInterrupt()
+    def test_calculate_default_height_uses_config_min_height(self):
+        config = {"snapshot": {"minHeight": 500}}
         with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT", "1"):
-            with self.assertRaises(KeyboardInterrupt):
-                calculate_default_height(page, 321)
+            self.assertEqual(calculate_default_height(321, config=config), 500)
 
-    def test_calculate_default_height_reraises_system_exit(self):
-        page = MagicMock()
-        page.evaluate.side_effect = SystemExit()
+    def test_calculate_default_height_uses_current_height_as_fallback(self):
         with patch.object(local, "PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT", "1"):
-            with self.assertRaises(SystemExit):
-                calculate_default_height(page, 321)
+            self.assertEqual(calculate_default_height(321), 321)
 
     @patch("requests.get")
     def test_get_responsive_widths(self, mock_get):


### PR DESCRIPTION
### Overview
Adds support for responsive snapshot capture, CORS iframe serialization, and cookie context capture to improve Percy snapshot fidelity and enable multi-width testing.

---

### Key Features

#### 1. **Responsive Snapshot Capture**
Enables capturing DOM snapshots at multiple viewport widths in a single call.

- Added `capture_responsive_dom()` to iterate through configured widths
- Fetches width configurations from Percy CLI via `get_responsive_widths()`
- Supports environment variables: `PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT`, `PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE`, `RESPONSIVE_CAPTURE_SLEEP_TIME`

**Usage:**
```python
percy_snapshot(page, "Homepage", responsiveSnapshotCapture=True, widths=[375, 768, 1280])
```

#### 2. **Cookie Context Capture**
Snapshots now include page cookies to preserve authentication and session state.

- Modified `get_serialized_dom()` to capture `page.context.cookies()`
- DOM snapshot structure changed from string to object: `{"html": "...", "cookies": [...]}`

#### 3. **CORS Iframe Capture**
Captures cross-origin iframe content previously inaccessible due to browser security.

- Added `process_frame()` to serialize cross-origin frames
- Injects Percy DOM script into each frame context
- Sequential processing to avoid Playwright thread-safety issues

---

### Code Changes

**percy/screenshot.py:**
- `is_percy_enabled()` → `_is_percy_enabled()` returns dict instead of string
- Added `get_serialized_dom()` with CORS iframe support
- Added responsive capture helpers
- Unified logging via `log()` helper

**Tests:**
- Added 59 test cases with 100% coverage
- New file `tests/test_init.py` for wrapper tests

**Infrastructure:**
- Added coverage enforcement (100% threshold)
- Updated Playwright `1.28.*` → `1.40.*`
- Updated Percy CLI to `^1.31.9-beta.5`

---

### Breaking Changes
- DOM snapshot structure changed from string to object
- Requires Percy CLI `^1.31.9-beta.5` or higher