### PR TITLE
ci: fix CLI-branch injection for this (non-JS) repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,11 @@ jobs:
           restore-keys: v1/${{ runner.os }}/node-${{ matrix.node }}/
       - name: Set up @percy/cli from git
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          BRANCH: ${{ github.event.inputs.branch }}
         run: |
           cd /tmp
-          git clone --branch ${{ github.event.inputs.branch }} --depth 1 https://github.com/percy/cli
+          git clone --branch "$BRANCH" --depth 1 https://github.com/percy/cli
           cd cli
           PERCY_PACKAGES=`find packages -mindepth 1 -maxdepth 1 -type d | sed -e 's/packages/@percy/g' | tr '\n' ' '`
           git log -1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,13 @@ jobs:
           yarn
           yarn build
           yarn global:link
-          cd ${{ github.workspace }} 
-          yarn remove @percy/cli && yarn link `echo $PERCY_PACKAGES`
-          npx percy --version
+          # Non-JS repo: there is no @percy/cli dependency to remove and no node
+          # project to `yarn link` into. yarn global:link already linked the
+          # built @percy/* packages; just put the freshly built `percy` on PATH
+          # for the test step (and verify it here).
+          GLOBAL_BIN="$(yarn global bin)"
+          echo "$GLOBAL_BIN" >> "$GITHUB_PATH"
+          export PATH="$GLOBAL_BIN:$PATH"
+          percy --version
        
       - run: make test-coverage


### PR DESCRIPTION
## What
The `Set up @percy/cli from git` step ran `yarn remove @percy/cli && yarn link …` in the workspace, but this is a Python repo with no `@percy/cli` dependency / node project — so `yarn remove` failed (`No lockfile`) and `percy` was never linked. CLI-branch regression silently never ran.

Fix: rely on `yarn global:link` (already run) and expose the freshly built `percy` on PATH for the test step.

## Verified
`workflow_dispatch` with `branch=master` → **passes** (clone/build/link + `make test-coverage` against the branch CLI): run 28334770557.

Part of PER-9772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)