### PR TITLE
chore: bump version to 1.0.3-beta.1

### DIFF
--- a/percy/version.py
+++ b/percy/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.3-beta.0"
+__version__ = "1.0.3-beta.1"


### PR DESCRIPTION
Version bump to `1.0.3-beta.1` to release the merged CORS-iframe + closed-shadow-DOM work (PER-7292).

Bumps `1.0.3-beta.0` → `1.0.3-beta.1` (next beta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)